### PR TITLE
fix: application compiles using BUILDING.md

### DIFF
--- a/src/platform.h
+++ b/src/platform.h
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <iostream>
 #include <istream>
 #include <map>


### PR DESCRIPTION
Hi, I've tried building this application on my Arch Linux machine using the following instructions from `BUILDING.md`:
```bash
git submodule update --init --recursive
cmake .
make
```

but the compiler gave an error about `std::function` not being declared in `fine.h`:
![image](https://github.com/user-attachments/assets/cf6dfa30-3709-43f3-bba0-7e2d31b09af4)

this can be fixed by including the `functional` header [which is where std::function is defined](https://en.cppreference.com/w/cpp/utility/functional/function)

I initially put this include in `fine.h` since that's the only file where it's necessary or where `std::function` is used, but I've noticed all c++ standard library headers are included in `platform.h` (which many other files include, one of which is `fine.h`), so I added the `functional` header to the `platform.h` c++ standard library include pile